### PR TITLE
Support IAM instance profiles for AWS credentials

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,14 +7,14 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    aws-sdk (2.7.0)
-      aws-sdk-resources (= 2.7.0)
-    aws-sdk-core (2.7.0)
+    aws-sdk (2.10.116)
+      aws-sdk-resources (= 2.10.116)
+    aws-sdk-core (2.10.116)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.7.0)
-      aws-sdk-core (= 2.7.0)
-    aws-sigv4 (1.0.0)
+    aws-sdk-resources (2.10.116)
+      aws-sdk-core (= 2.10.116)
+    aws-sigv4 (1.0.2)
     diff-lcs (1.2.5)
     jmespath (1.3.1)
     rspec (3.3.0)
@@ -39,4 +39,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   1.13.6
+   1.15.4

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ To eliminate the big image file uploading issue and the security risk, the idea 
 
 ## Environment variables
 
- - **CONVERT_S3_REGION** - AWS region for S3, default value will be reading from `AWS_REGION` if this environment variable is not set. (required)
- - **CONVERT_LAMBDA_REGION** - AWS region for Lambda, default value will be reading from `AWS_REGION` if this environment variable is not set. (required)
- - **CONVERT_ACCESS_KEY** - AWS access key, default value will be reading from `AWS_ACCESS_KEY_ID` if this environment variable is not set. (required)
- - **CONVERT_SECRET_ACCESS_KEY** - AWS secret key, default value will be reading from `AWS_SECRET_ACCESS_KEY` if this environment variable is not set. (required)
+ - **CONVERT_S3_REGION** - AWS region for S3, default value will be read from `AWS_REGION` if this environment variable is not set.
+ - **CONVERT_LAMBDA_REGION** - AWS region for Lambda, default value will be read from `AWS_REGION` if this environment variable is not set.
+ - **CONVERT_ACCESS_KEY** - AWS access key, default value will follow standard `aws-sdk` credential lookup sequence
+ - **CONVERT_SECRET_ACCESS_KEY** - AWS secret key, default value will follow standard `aws-sdk` credential lookup sequence
  - **CONVERT_S3_BUCKET** - AWS S3 bucket. (required)
  - **CONVERT_S3_KEY_PREFIX** - AWS S3 temporary file uploading prefix, default value is `_convert_tmp/`
  - **CONVERT_LAMBDA_FUNCTION** - Name of the AWS Lambda function to invoke, default value is `image-convert-prod`

--- a/lib/lambda_convert/cli.rb
+++ b/lib/lambda_convert/cli.rb
@@ -1,4 +1,3 @@
-require 'rubygems'
 require 'json'
 require 'securerandom'
 require 'English'
@@ -12,10 +11,11 @@ module LambdaConvert
       attr_accessor :logger
 
       def aws_credentials
-        Aws::Credentials.new(
-          ENV['CONVERT_ACCESS_KEY'] || ENV['AWS_ACCESS_KEY_ID'],
-          ENV['CONVERT_SECRET_ACCESS_KEY'] || ENV['AWS_SECRET_ACCESS_KEY']
-        )
+        if ENV['CONVERT_ACCESS_KEY'] && ENV['CONVERT_SECRET_ACCESS_KEY']
+          Aws::Credentials.new(
+            ENV['CONVERT_ACCESS_KEY'], ENV['CONVERT_SECRET_ACCESS_KEY']
+          )
+        end
       end
 
       def lambda_region


### PR DESCRIPTION
Don't require that an AWS access key id and key secret be set. Permit the
credential chain in `aws-sdk` to do its magic and fall-through so that IAM
instance profiles work.

Bump the version of `aws-sdk` used in the `Gemfile.lock` to pick up a year's
worth of changes.

Remove unneeded `require`.