### PR TITLE
Bump dependencies for AWS SDK V3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,21 +2,33 @@ PATH
   remote: .
   specs:
     lambda_convert (0.0.6)
-      aws-sdk (~> 2.6)
+      aws-sdk-lambda (~> 1.0)
+      aws-sdk-s3 (~> 1.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    aws-sdk (2.10.116)
-      aws-sdk-resources (= 2.10.116)
-    aws-sdk-core (2.10.116)
-      aws-sigv4 (~> 1.0)
+    aws-eventstream (1.2.0)
+    aws-partitions (1.503.0)
+    aws-sdk-core (3.121.0)
+      aws-eventstream (~> 1, >= 1.0.2)
+      aws-partitions (~> 1, >= 1.239.0)
+      aws-sigv4 (~> 1.1)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.10.116)
-      aws-sdk-core (= 2.10.116)
-    aws-sigv4 (1.0.2)
+    aws-sdk-kms (1.48.0)
+      aws-sdk-core (~> 3, >= 3.120.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-lambda (1.68.0)
+      aws-sdk-core (~> 3, >= 3.120.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-s3 (1.103.0)
+      aws-sdk-core (~> 3, >= 3.120.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.4)
+    aws-sigv4 (1.4.0)
+      aws-eventstream (~> 1, >= 1.0.2)
     diff-lcs (1.2.5)
-    jmespath (1.3.1)
+    jmespath (1.4.0)
     rspec (3.3.0)
       rspec-core (~> 3.3.0)
       rspec-expectations (~> 3.3.0)
@@ -39,4 +51,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   1.15.4
+   1.17.3

--- a/lambda_convert.gemspec
+++ b/lambda_convert.gemspec
@@ -13,5 +13,6 @@ Gem::Specification.new do |s|
   s.bindir      = 'bin'
   s.executables = s.files.grep(%r{^bin/}) { |f| File.basename(f) }
   s.license     = 'MIT'
-  s.add_runtime_dependency 'aws-sdk', '~> 2.6'
+  s.add_runtime_dependency 'aws-sdk-lambda', '~> 1.0'
+  s.add_runtime_dependency 'aws-sdk-s3', '~> 1.0'
 end

--- a/lib/lambda_convert/cli.rb
+++ b/lib/lambda_convert/cli.rb
@@ -2,7 +2,8 @@ require 'json'
 require 'securerandom'
 require 'English'
 
-require 'aws-sdk'
+require 'aws-sdk-lambda'
+require 'aws-sdk-s3'
 
 module LambdaConvert
   # `convert` command line tool implementation


### PR DESCRIPTION
Updates dependencies to make this compatible with V3 of AWS's Ruby SDK.

Follows https://github.com/aws/aws-sdk-ruby/blob/version-3/V3_UPGRADING_GUIDE.md#library-maintainer